### PR TITLE
🐳 Update Dockerfile to use apt instead of apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/actions/actions-runner:latest
 
 # Update and install base dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt install -y \
     software-properties-common \
     curl \
     wget \


### PR DESCRIPTION
## 🔍 Samenvatting

<!-- Geef een korte beschrijving van deze wijziging (1-3 zinnen) -->

Deze PR veranderd het gebruik van apt-get naar apt net zoals in de parent image
