### PR TITLE
👷 Update workflows to use brixion-runner for Github Actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: brixion-runners
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## 🔍 Samenvatting

Deze PR past de `runs-on` in de workflows aan naar `brixion-runners` zodat onze eigen Github Action runners worden gebruikt.

## ✅ Checklist

- [ ] Code is lokaal getest
- [ ] Tests zijn toegevoegd/aangepast
- [ ] Documentatie bijgewerkt (indien nodig)