### PR TITLE
🐳 Add GitHub CLI to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     # Git
     git \
     git-lfs \
+    gh \
     # Node.js (installed via nodesource script)
     nodejs \
     # Python


### PR DESCRIPTION
## 🔍 Samenvatting

Deze PR voegt GitHub CLI (`gh`) toe aan de Dockerfile van onze GitHub runners

## 📝 Beschrijving

- Installeer package `gh` in de Docker image

## ✅ Checklist

- [x] Code is lokaal getest
- [ ] Tests zijn toegevoegd/aangepast
- [ ] Documentatie bijgewerkt (indien nodig)
